### PR TITLE
Fix recipe for StatsBase.Histogram

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -39,6 +39,6 @@ Plots.@deps cdensity path
 # StatsBase.Histogram
 
 @recipe function f(h::StatsBase.Histogram)
-    seriestype := :histogram
+    seriestype := :bar
     h.edges[1], h.weights
 end


### PR DESCRIPTION
Before, a new histogram was calculated using the weights as input.